### PR TITLE
force Light theme in plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,10 @@
         </feature>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="UIUserInterfaceStyle">
+            <string>Light</string>
+        </config-file>
+
         <js-module src="www/ios/DatePicker.js" name="DatePicker">
             <clobbers target="datePicker" />
         </js-module>


### PR DESCRIPTION
force Light theme in plist to fix ui bug where datepicker text is white on white background when device is configured in Dark theme